### PR TITLE
Fix cumulus logger duplicate logging messages

### DIFF
--- a/example/task.py
+++ b/example/task.py
@@ -4,7 +4,7 @@ import sys
 from run_cumulus_task import run_cumulus_task
 from cumulus_logger import CumulusLogger
 
-logger = CumulusLogger()
+logger = CumulusLogger(name="log_name")
 
 schemas = {
     "input": "schemas/input.json",


### PR DESCRIPTION
Fix cumulus logger duplicate logging messages, run_cumulus_task also uses CumulusLogger, so without specifying name it will create duplicate messages