### PR TITLE
Allow braces in log messages

### DIFF
--- a/cumulus_logger.py
+++ b/cumulus_logger.py
@@ -209,8 +209,14 @@ class CumulusLogger:
         if isinstance(message, Mapping):
             msg.update(message)
         else:
-            # In case message is not a string (e.g., exception) use str
-            fmt_message = str(message).format(*args, **kwargs)
+            # - In case message is not a string (e.g., exception) use str
+            # - Only call str.format() if args or kwargs are actually given, so
+            #   that curly braces in the message do not cause an IndexError or
+            #   KeyError here
+            fmt_message = str(message)
+            if args or kwargs:
+                fmt_message = fmt_message.format(*args, **kwargs)
+
             ex_message = _get_exception_message(**kwargs)
             msg["message"] = " ".join(filter(None, [fmt_message, ex_message]))
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -7,6 +7,19 @@ from helpers import LambdaContextMock, create_event, create_parameter_event
 
 
 class TestLogger(unittest.TestCase):
+    def set_up_logger(self, event=None, context=None, logger=None):
+        if event is None:
+            event = create_event()
+
+        if context is None:
+            context = LambdaContextMock()
+
+        if logger is None:
+            logger = CumulusLogger()
+        logger.setMetadata(event, context)
+
+        return logger
+
     def test_simple_message(self):
         event, context = create_event(), LambdaContextMock()
         logger = CumulusLogger()
@@ -110,3 +123,18 @@ class TestLogger(unittest.TestCase):
         logger.debug("test logging level debug")
         logger.info("test logging level info")
         logger.warning("test logging level warning")
+
+    def test_simple_message_with_braces_no_args(self):
+        logger = self.set_up_logger()
+        msg = logger.createMessage("test simple {}")
+        self.assertEqual(msg["message"], "test simple {}")
+
+    def test_simple_message_with_braces_no_kwargs(self):
+        logger = self.set_up_logger()
+        msg = logger.createMessage("test {simple}")
+        self.assertEqual(msg["message"], "test {simple}")
+
+    def test_message_with_json_no_kwargs(self):
+        logger = self.set_up_logger()
+        msg = logger.createMessage('some message about JSON and the json: {"test": "simple"}')
+        self.assertEqual(msg["message"], 'some message about JSON and the json: {"test": "simple"}')

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -22,8 +22,7 @@ class TestLogger(unittest.TestCase):
 
     def test_simple_message(self):
         event, context = create_event(), LambdaContextMock()
-        logger = CumulusLogger()
-        logger.setMetadata(event, context)
+        logger = self.set_up_logger(event=event, context=context)
         msg = logger.createMessage("test simple")
         self.assertEqual(msg["sender"], context.function_name)
         self.assertEqual(msg["version"], context.function_version)
@@ -46,8 +45,7 @@ class TestLogger(unittest.TestCase):
 
     def test_parameter_configured_message(self):
         event, context = create_parameter_event(), LambdaContextMock()
-        logger = CumulusLogger()
-        logger.setMetadata(event, context)
+        logger = self.set_up_logger(event=event, context=context)
         msg = logger.createMessage("test parameter event")
         self.assertEqual(msg["sender"], context.function_name)
         self.assertEqual(msg["version"], context.function_version)
@@ -71,25 +69,19 @@ class TestLogger(unittest.TestCase):
         logger.info("test parameter configured message")
 
     def test_empty_event_and_context(self):
-        event, context = {}, {}
-        logger = CumulusLogger()
-        logger.setMetadata(event, context)
+        logger = self.set_up_logger(event={}, context={})
         msg = logger.createMessage("empty event and context")
         self.assertEqual(set(msg.keys()),
                          {"version", "sender", "message", "timestamp"})
 
     def test_formatted_message(self):
-        event, context = create_event(), LambdaContextMock()
-        logger = CumulusLogger()
-        logger.setMetadata(event, context)
+        logger = self.set_up_logger()
         msg = logger.createMessage("test formatted {} {}", "foo", "bar")
         self.assertEqual(msg["message"], "test formatted foo bar")
         logger.debug("test formatted {} {}", "foo", "bar")
 
     def test_error_message(self):
-        event, context = create_event(), LambdaContextMock()
-        logger = CumulusLogger()
-        logger.setMetadata(event, context)
+        logger = self.set_up_logger()
         try:
             1 / 0
         except ZeroDivisionError as ex:
@@ -116,9 +108,7 @@ class TestLogger(unittest.TestCase):
             logger.trace("test exc_info", exc_info=ex)
 
     def test_logger_name_loglevel(self):
-        event, context = create_event(), LambdaContextMock()
-        logger = CumulusLogger('logger_test', logging.INFO)
-        logger.setMetadata(event, context)
+        logger = self.set_up_logger(logger=CumulusLogger('logger_test', logging.INFO))
         self.assertTrue(logger.logger.getEffectiveLevel() == logging.INFO)
         logger.debug("test logging level debug")
         logger.info("test logging level info")


### PR DESCRIPTION
* add some failing tests for new behavior 
* DRY out other tests with helper function
* in `CumulusLogger.createMessage`, call `str.format` iff args/kwargs are given

    * this allows the user more freedom in what is in their logging and error strings,
including JSON strings plus additional text about the JSON; with the previous
behavior, `createMessage` raises an `IndexError` or `KeyError` if the log (or
error) message has any curly braces in it but no args/kwargs due to the
`str.format` call
    * fixes the newly added unit tests

[Fixes #38]