### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-cumulus-message-adapter>=2.0.0<2.1.0
+cumulus-message-adapter>=2.0.0, <2.1.0


### PR DESCRIPTION
Closes #47 

I am currently unable to install this package from pip. I believe this PR will also solve my problem.


This is the error I get when trying to install this with a python 3.10 interpreter:
```
pip install cumulus-message-adapter-python
Creating virtualenv c_b3eufZ-py3.10 in /home/dockeruser/.cache/pypoetry/virtualenvs
Collecting cumulus-message-adapter-python
  Downloading cumulus_message_adapter_python-2.0.1.tar.gz (15 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [5 lines of output]
      /tmp/pip-install-3n5cqohq/cumulus-message-adapter-python_3dc762a1bd4d4660a6ae2db1c43a8e02/setup.py:6: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
        import imp
      error in cumulus_message_adapter_python setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          cumulus-message-adapter>=2.0.0<2.1.0
                                 ~~~~~~~^
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```