### PR TITLE
Add update to fix release process move version.py->.toml

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-VERSION_TAG=$(awk -F\' '{print $2}' version.py)
+VERSION_TAG=$(head pyproject.toml  |grep version |awk -F '"' '{print $2}')
 LATEST_TAG=$(curl -H \
   "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/nasa/cumulus-message-adapter-python/tags | jq --raw-output '.[0].name')


### PR DESCRIPTION
The prior approved PR #56 was missing an update to the publish script as the version needs to be pulled from the .toml file.   This is a quick fix to read the `pyproject.toml` file. 